### PR TITLE
#4 Add option for forcibly updating cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,12 @@ If it is located in a current directory or in the Azely's config directory, user
 ### Cached information
 
 Object and location information obtained from online services is cached to [TOML] files (`object.toml`, `location.toml`) in the Azely's config directory with the same format as user-defined files.
+If a query argument is given with `'!'` at the beginning of it, then the cached values are forcibly updated by a new acquisition.
+This is useful, for example, when users want to update a current location:
+
+```python
+>>> df = azely.compute('Sun', '!here', '2020-01-01')
+```
 
 ### Customizing defualt values
 

--- a/azely/location.py
+++ b/azely/location.py
@@ -53,7 +53,6 @@ __all__ = ["Location", "get_location"]
 
 
 # standard library
-import re
 from dataclasses import asdict, dataclass
 from datetime import tzinfo
 from typing import Dict
@@ -89,7 +88,6 @@ LocationDict = Dict[str, str]
 # query instances
 tf = TimezoneFinder()
 osm = Nominatim(user_agent="azely")
-re_here = re.compile(r"^!\s*" + HERE)
 
 
 # data classes
@@ -169,7 +167,7 @@ def get_location(query: str = HERE, timeout: int = TIMEOUT) -> Location:
 
     if DELIMITER in query:
         return Location(**get_location_by_user(query))
-    elif re_here.search(query.lower()):
+    elif query.lower().lstrip("! ") == HERE:
         return Location(**get_location_by_ip(query, timeout))
     else:
         return Location(**get_location_by_query(query, timeout))

--- a/azely/location.py
+++ b/azely/location.py
@@ -53,6 +53,7 @@ __all__ = ["Location", "get_location"]
 
 
 # standard library
+import re
 from dataclasses import asdict, dataclass
 from datetime import tzinfo
 from typing import Dict
@@ -88,6 +89,7 @@ LocationDict = Dict[str, str]
 # query instances
 tf = TimezoneFinder()
 osm = Nominatim(user_agent="azely")
+re_here = re.compile(r"^!\s*" + HERE)
 
 
 # data classes
@@ -167,7 +169,7 @@ def get_location(query: str = HERE, timeout: int = TIMEOUT) -> Location:
 
     if DELIMITER in query:
         return Location(**get_location_by_user(query))
-    elif query.lower() == HERE:
+    elif re_here.search(query.lower()):
         return Location(**get_location_by_ip(query, timeout))
     else:
         return Location(**get_location_by_query(query, timeout))

--- a/azely/object.py
+++ b/azely/object.py
@@ -159,7 +159,7 @@ def get_object(query: str, frame: str = FRAME, timeout: int = TIMEOUT) -> Object
     """
     if DELIMITER in query:
         return Object(**get_object_by_user(query))
-    elif query.lower() in solar_system_ephemeris.bodies:
+    elif query.lower().lstrip("! ") in solar_system_ephemeris.bodies:
         return Object(**get_object_of_solar(query))
     else:
         return Object(**get_object_by_query(query, frame, timeout))

--- a/azely/utils.py
+++ b/azely/utils.py
@@ -125,7 +125,7 @@ class cache_to:
 
     def __call__(self, func: Callable) -> Callable:
         sig = signature(func)
-        pattern = re.compile(r"^(!\s*)(!\w+)$")
+        pattern = re.compile(r"^(!\s*)([!\w]+)$")
 
         @wraps(func)
         def wrapper(*args, **kwargs):

--- a/tests/test_compute.py
+++ b/tests/test_compute.py
@@ -41,7 +41,7 @@ Asia/Tokyo,az,el,lst
 
 # test functions
 def test_compute():
-    result = compute("NGC1068", "ALMA AOS", "2020-02-01", view="Tokyo", freq="1H")
+    result = compute("!NGC1068", "!ALMA AOS", "2020-02-01", view="Tokyo", freq="1H")
     expected = pd.read_csv(StringIO(data), index_col=0)
     expected = expected.set_index(result.index)
 

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -18,7 +18,7 @@ expected = Location(
 
 # test functions
 def test_location_by_query():
-    assert get_location(expected.name) == expected
+    assert get_location(f"!{expected.name}") == expected
 
 
 def test_location_by_user():

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -17,11 +17,11 @@ expected_icrs = Object(
 
 # test functions
 def test_object_of_solar():
-    assert get_object(expected_solar.name) == expected_solar
+    assert get_object(f"!{expected_solar.name}") == expected_solar
 
 
 def test_object_by_query():
-    assert get_object(expected_icrs.name) == expected_icrs
+    assert get_object(f"!{expected_icrs.name}") == expected_icrs
 
 
 def test_location_by_user():


### PR DESCRIPTION
Implement an option for forcibly updating cache
when query string is given with the special keyword (`!`).

```python
import azely

# not updated (if cached value already exists)
location = azely.get_location("here")

# forcibly updated
location = azely.get_location("!here")
```