### PR TITLE
#16 Use case-insensitive query

### DIFF
--- a/azely/object.py
+++ b/azely/object.py
@@ -179,7 +179,7 @@ def get_object_by_user(query: str) -> ObjectDict:
 @cache_to(AZELY_OBJECT)
 def get_object_of_solar(query: str) -> ObjectDict:
     """Get object information of the solar system."""
-    return Object(query, SOLAR, "NaN", "NaN").to_dict()
+    return Object(query.capitalize(), SOLAR, "", "").to_dict()
 
 
 @cache_to(AZELY_OBJECT)

--- a/azely/time.py
+++ b/azely/time.py
@@ -163,9 +163,9 @@ def get_time(
     except UnknownTimeZoneError:
         tzinfo = get_location(view, timeout).tzinfo
 
-    if query == NOW:
+    if query.lower() == NOW:
         return Time(get_time_now(tzinfo))
-    elif query == TODAY:
+    elif query.lower() == TODAY:
         return Time(get_time_today(freq, tzinfo))
     else:
         parser = partial(parse, dayfirst=dayfirst, yearfirst=yearfirst)

--- a/azely/utils.py
+++ b/azely/utils.py
@@ -19,6 +19,7 @@ from typing import Any, Callable, Dict, Union
 
 
 # dependent packages
+from requests.utils import CaseInsensitiveDict
 from toml import TomlDecodeError, dump, load
 
 
@@ -226,7 +227,7 @@ def ensure_existance(path: PathLike) -> Path:
     return path
 
 
-class TOMLDict(dict):
+class TOMLDict(CaseInsensitiveDict):
     """Open and update a TOML file as a dictionary."""
 
     def __init__(self, path: PathLike) -> None:

--- a/tests/test_object.py
+++ b/tests/test_object.py
@@ -8,7 +8,7 @@ from toml import dump
 
 
 # constants
-expected_solar = Object(name="Sun", frame="solar", longitude="NaN", latitude="NaN")
+expected_solar = Object(name="Sun", frame="solar", longitude="", latitude="")
 
 expected_icrs = Object(
     name="NGC1068", frame="icrs", longitude="02h42m40.771s", latitude="-00d00m47.84s",


### PR DESCRIPTION
Make sure that `'query'`, `'QUERY'`, and `'QuErY'` are considered to be same.
Note that other parameters are still case-sensitive at this moment:
For example, `frame='ICRS'` is not allowed.