### PR TITLE
Add testing support for 3.12 and 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Release](https://img.shields.io/pypi/v/azely?label=Release&color=cornflowerblue&style=flat-square)](https://pypi.org/project/azely/)
 [![Python](https://img.shields.io/pypi/pyversions/azely?label=Python&color=cornflowerblue&style=flat-square)](https://pypi.org/project/azely/)
-[![Downloads](https://img.shields.io/pypi/dm/azely?label=Downloads&color=cornflowerblue&style=flat-square)](https://pepy.tech/project/azely)
+[![Downloads](https://img.shields.io/pypi/dm/azely?label=Downloads&color=cornflowerblue&style=flat-square)](https://pepy.tech/projects/azely)
 [![DOI](https://img.shields.io/badge/DOI-10.5281/zenodo.3680060-cornflowerblue?style=flat-square)](https://doi.org/10.5281/zenodo.3680060)
 [![Tests](https://img.shields.io/github/workflow/status/astropenguin/azely/Tests?label=Tests&style=flat-square)](https://github.com/astropenguin/azely/actions)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In fact azely offers one-liner to compute and plot, for example, one-day elevati
 
 ## Requirements
 
-- **Python:** 3.7, 3.8, 3.9, and 3.10 (tested by author)
+- **Python:** 3.9, 3.10, 3.11, 3.12, 3.13 (tested by author)
 - **Dependencies:** See [pyproject.toml](https://github.com/astropenguin/azely/blob/v0.7.0/pyproject.toml)
 
 ## Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/astropenguin/azely/"
 documentation = "https://astropenguin.github.io/azely/"
 
 [tool.poetry.dependencies]
-python = ">=3.9, <3.13"
+python = ">=3.9, <3.14"
 astropy = "^5.0"
 pandas = "^1.5 | ^2.0"
 pandas-stubs = "^1.5 | ^2.0"


### PR DESCRIPTION
I was getting install errors on 3.12 and noticed it wasn't being tested.